### PR TITLE
refactored _get_longest_word_ending

### DIFF
--- a/tests/unit/test_toponym.py
+++ b/tests/unit/test_toponym.py
@@ -1,0 +1,23 @@
+from toponym import toponym, topodict
+
+td = {
+    "i": {
+        "nominative": ["", 0],
+        "genitive": ["o", 1]
+    },
+    "ti": {
+        "nominative": ["", 0],
+        "genitive": ["o", 1]
+    },
+    "esti": {
+        "nominative": ["", 0],
+        "genitive": ["o", 1]
+    }
+}
+
+td = topodict.Topodict(language='test', file=td)
+td.load()
+
+def test_get_longest_word_ending():
+    tn = toponym.Toponym("Testi", td)
+    assert tn._get_longest_word_ending() == "esti"

--- a/toponym/toponym.py
+++ b/toponym/toponym.py
@@ -34,21 +34,9 @@ class Toponym(case.Case):
                 )
 
     def _get_longest_word_ending(self):
-        deepest_word_ending = ""
-        reversed_text = "".join([x for x in reversed(self.word)])
+        """
+        """
+        possible_endings = [self.word[i:] for i in range(len(self.word))]
+        matching_endings = [x for x in possible_endings if x in self.topodict._dict.keys()]
 
-        if reversed_text[0] in self.topodict._dict.keys():
-            deepest_word_ending = deepest_word_ending + reversed_text[0]
-
-        x = True
-        while x == True:
-                for x in reversed_text[1:]:
-                    if deepest_word_ending in self.topodict._dict.keys():
-                        if x + deepest_word_ending in self.topodict._dict.keys():
-                            deepest_word_ending = x + deepest_word_ending
-                        else:
-                            break
-                    else:
-                        break
-
-        return deepest_word_ending
+        return max(matching_endings, key=len)


### PR DESCRIPTION
before:

- could not handle cases where "st"  was not included in topodictionary but "est" was.
- used while loop

now:
- without while loop
- first create a list of possible endings eg. "Test" = ["t", "st", "est", "Test"]. Then create a second list of endings that are in topodictionary.keys(). finally return longest string in matching endings.
